### PR TITLE
docs: fix macos default config location

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -15,7 +15,7 @@
 
 # The default directory for application data, such as the stored commands database.
 # If this value is left empty, the application will use the system's default data directory:
-# - ~/.local/share/intelli-shell (on Linux/macOS, unless overridden by XDG_DATA_HOME)
+# - ~/.local/share/intelli-shell (on Linux, unless overridden by XDG_DATA_HOME)
 # - ~/Library/Application Support/org.IntelliShell.Intelli-Shell (on macOS)
 # - %APPDATA%\IntelliShell\Intelli-Shell\data (on Windows)
 data_dir = ""

--- a/docs/src/configuration/index.md
+++ b/docs/src/configuration/index.md
@@ -20,7 +20,7 @@ setups.
 If the environment variable is not set, IntelliShell falls back to searching in these default locations:
 
 - **Linux**: `~/.config/intelli-shell/config.toml`
-- **macOS**: `~/Library/Preferences/org.IntelliShell.Intelli-Shell/config.toml`
+- **macOS**: `~/Library/Application Support/org.IntelliShell.Intelli-Shell/config.toml`
 - **Windows**: `%APPDATA%\IntelliShell\Intelli-Shell\config\config.toml`
 
 If no configuration file is found, IntelliShell will use its built-in default settings. To get started with

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -62,7 +62,7 @@ this by setting the `data_dir` option in your configuration file.
 
 - **Configuration File**:
   - _Linux_: `~/.config/intelli-shell/config.toml`
-  - _macOS_: `~/Library/Preferences/org.IntelliShell.Intelli-Shell/config.toml`
+  - _macOS_: `~/Library/Application Support/org.IntelliShell.Intelli-Shell/config.toml`
   - _Windows_: `%APPDATA%\IntelliShell\Intelli-Shell\config\config.toml`
 
 - **Data Files (Database, Logs)**:


### PR DESCRIPTION
From the documentation for `directories`:

> ### Example
>
> ```rs
> if let Some(proj_dirs) = ProjectDirs::from("com", "Foo Corp",  "Bar App") {
>     proj_dirs.config_dir();
>     // Lin: /home/alice/.config/barapp
>     // Win: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config
>     // Mac: /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App
> }
> ```

~~I havent checked to see if there are other places where this info needs to be updated~~ also needs to be updated in https://github.com/lasantosr/intelli-shell/blob/6af8e76952a9b8f004e8d340612e369d99d0ce3b/docs/src/troubleshooting.md?plain=1#L65 and https://github.com/lasantosr/intelli-shell/blob/6af8e76952a9b8f004e8d340612e369d99d0ce3b/docs/src/configuration/index.md?plain=1#L23