### PR TITLE
add support for custom workspace directories

### DIFF
--- a/docs/src/guide/workspace.md
+++ b/docs/src/guide/workspace.md
@@ -15,6 +15,31 @@ given top priority in search results, appearing above your personal and `tldr` c
 > **Note**: You can temporarily disable this feature by setting the `INTELLI_SKIP_WORKSPACE=1` environment variable. If
 > this variable is set, IntelliShell will not search for or load any `.intellishell` file.
 
+### Loading Additional Workspace Files
+
+In addition to the local workspace file, you can load `.intellishell` files from additional directories by setting the
+`INTELLI_WORKSPACE_PATH` environment variable.
+
+The variable should contain a list of directory paths separated by:
+- `:` (colon) on Linux and macOS
+- `;` (semicolon) on Windows
+
+**Example (Linux/macOS):**
+```sh
+export INTELLI_WORKSPACE_PATH="$HOME/.intellishell-global:/opt/company-commands"
+```
+
+**Example (Windows):**
+```powershell
+$env:INTELLI_WORKSPACE_PATH="C:\Users\YourName\.intellishell-global;C:\Company\commands"
+```
+
+Each directory in the path will be checked for a `.intellishell` file, and all found files will be loaded in order:
+1. First, the local workspace file (from current directory or parent)
+2. Then, additional files from `INTELLI_WORKSPACE_PATH` in the order they appear
+
+Each file is tagged with its directory name for easy identification in the search results.
+
 ### Key Behaviors
 
 - **Workspace-Aware**: Commands and completions are only available when you are working inside that workspace's directory


### PR DESCRIPTION
Adds INTELLI_WORKSPACE_PATH environment variable to load .intellishell files from additional directories beyond the current working directory tree. Updated workspace documentation with usage examples.

Usage:
```sh
export INTELLI_WORKSPACE_PATH="$HOME/.intellishell-global:$HOME/custom/path"
```