### PR TITLE
docs: display ctrl+x as the default AI shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once any interface is shown, you can use these keys:
 - **`ctrl+d`**: Delete the highlighted item
 - **`enter` / `tab`**: Confirm a selection or move to the next step
 - **`ctrl+enter` / `ctrl+r`**: Execute the highlighted command immediately
-- **`ctrl+i` / `ctrl+x`**: Prompt AI (when searching or creating commands)
+- **`ctrl+x` / `ctrl+i`**: Prompt AI (when searching or creating commands)
 
 _These keybindings are fully customizable; in fact, you can configure everything from themes to search behavior. See
 the [Keybindings Configuration](https://lasantosr.github.io/intelli-shell/configuration/keybindings.html) page for
@@ -114,7 +114,7 @@ available options._
   replacement UI will still appear if the command has variables.
 
 - **Learn Commands on the Fly**: Can't find the command you're looking for? Just describe it in natural language and
-  press `ctrl+i` while searching to let the AI write it for you.
+  press `ctrl+x` while searching to let the AI write it for you.
 
 - **Alias your favorites**: Use aliases to "pin" different sets of favorite values for the same command. For example,
   bookmark `cd {{path}}` with a `cd` alias and you can regularly use `cd` but if you hit `ctrl+space` it will show your

--- a/docs/src/configuration/keybindings.md
+++ b/docs/src/configuration/keybindings.md
@@ -26,7 +26,7 @@ The format and a list of available actions are detailed below. Note that if a de
 | `delete`           | Deletes the currently highlighted item (e.g., a bookmarked command)   | `ctrl-d`                  |
 | `confirm`          | Confirms a selection or moves to the next step (e.g., variable entry) | `tab`, `enter`            |
 | `execute`          | Executes the highlighted command instead of just selecting it         | `ctrl-enter`, `ctrl-r`    |
-| `ai`               | Prompts ai for suggestions                                            | `ctrl-i`, `ctrl-x`        |
+| `ai`               | Prompts ai for suggestions                                            | `ctrl-x`, `ctrl-i`        |
 | `search_mode`      | Cycles through the available search modes (auto, fuzzy, regex, etc.)  | `ctrl-s`                  |
 | `search_user_only` | Toggles whether to filter user commands only in the search results    | `ctrl-o`                  |
 | `variable_next`    | Moves to the next variable when replacing template variables          | `ctrl-tab`                |

--- a/docs/src/guide/introduction_to_ai.md
+++ b/docs/src/guide/introduction_to_ai.md
@@ -15,18 +15,18 @@ an expert assistant who knows the syntax for thousands of tools, ready to help y
 Enabling AI integration powers up several key workflows:
 
 - **Generate Commands from Search**: Can't find the command you're looking for? In the search UI (<kbd>Ctrl</kbd>+<kbd>Space</kbd>),
-  type a description of what you want to do (e.g., _"find all files larger than 10MB"_) and press <kbd>Ctrl</kbd>+<kbd>I</kbd>
+  type a description of what you want to do (e.g., _"find all files larger than 10MB"_) and press <kbd>Ctrl</kbd>+<kbd>X</kbd>
   to let the AI write the command for you.
 
 - **Fix Failing Commands**: When a command fails, recall it from your history and press <kbd>Ctrl</kbd>+<kbd>X</kbd>. The
   AI will analyze the command and the error message to suggest a working version or explain next steps.
 
 - **Create New Bookmarks from a Prompt**: When bookmarking (<kbd>Ctrl</kbd>+<kbd>B</kbd>), you can provide a
-  description instead of a command and press <kbd>Ctrl</kbd>+<kbd>I</kbd>. The AI will generate the command template
+  description instead of a command and press <kbd>Ctrl</kbd>+<kbd>X</kbd>. The AI will generate the command template
   for you, which you can then edit and save.
 
 - **Generate Dynamic Completions**: When creating a new completion provide the root command and variable, optionally
-  describing what you need (e.g., _"list all running docker containers"_) on the provider, then press <kbd>Ctrl</kbd>+<kbd>I</kbd>.
+  describing what you need (e.g., _"list all running docker containers"_) on the provider, then press <kbd>Ctrl</kbd>+<kbd>X</kbd>.
   The AI will generate the shell command to produce the suggestions.
 
 - **Import from Anywhere**: The `import` command gains the ability to parse unstructured text. You can point it at

--- a/docs/src/reference/completion_new.md
+++ b/docs/src/reference/completion_new.md
@@ -3,8 +3,8 @@
 The `new` subcommand adds a new dynamic completion for a variable. This allows you to specify a shell command that will
 be executed to generate a list of possible values for a variable.
 
->💡 **Tip**: Can't figure out the exact command details? While in the interactive TUI, you can press <kbd>Ctrl</kbd>+<kbd>I</kbd>
-> or <kbd>Ctrl</kbd>+<kbd>X</kbd> with a natural language description on the provider field to prompt AI for a command.
+>💡 **Tip**: Can't figure out the exact command details? While in the interactive TUI, you can press <kbd>Ctrl</kbd>+<kbd>X</kbd>
+> with a natural language description on the provider field to prompt AI for a command.
 
 ## Usage
 

--- a/docs/src/reference/new.md
+++ b/docs/src/reference/new.md
@@ -6,8 +6,8 @@ While commands are typically bookmarked interactively using the <kbd>Ctrl</kbd>+
 a **non-interactive** way to add new entries. This is particularly useful for scripting, batch-importing from other tools,
 or when you want to add a command without breaking your terminal flow.
 
->💡 **Tip**: Can't remember the exact command details? While in the interactive TUI, you can press <kbd>Ctrl</kbd>+<kbd>I</kbd>
-> or <kbd>Ctrl</kbd>+<kbd>X</kbd> with a natural language description to prompt AI for a command.
+>💡 **Tip**: Can't remember the exact command details? While in the interactive TUI, you can press <kbd>Ctrl</kbd>+<kbd>X</kbd>
+> with a natural language description to prompt AI for a command.
 
 ## Usage
 

--- a/docs/src/reference/search.md
+++ b/docs/src/reference/search.md
@@ -6,8 +6,8 @@ By default, this command performs a non-interactive search and prints matching c
 interactive search TUI (the behavior of the <kbd>Ctrl</kbd>+<kbd>Space</kbd> hotkey), you must use the `-i` or
 `--interactive` flag.
 
->💡 **Tip**: Can't find what you're looking for? While in the interactive TUI, you can press <kbd>Ctrl</kbd>+<kbd>I</kbd>
-> or <kbd>Ctrl</kbd>+<kbd>X</kbd> with a natural language query to prompt AI for commands.
+>💡 **Tip**: Can't find what you're looking for? While in the interactive TUI, you can press <kbd>Ctrl</kbd>+<kbd>X</kbd>
+> with a natural language query to prompt AI for commands.
 
 ## Usage
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -30,7 +30,8 @@ If hotkeys like <kbd>Ctrl</kbd>+<kbd>Space</kbd> or <kbd>Ctrl</kbd>+<kbd>B</kbd>
          ```
   
    - **Terminal Limitations**: Some terminal emulators do not forward all key combinations to the shell. For instance,
-     <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (the default "execute" hotkey) is not supported by many terminals.
+     <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (the default "execute" hotkey) and <kbd>Ctrl</kbd>+<kbd>I</kbd> are not supported
+     by many terminals.
 
    - **Solution**: If you cannot configure your environment or IDE to forward the keys, simply change the conflicting
      hotkey in IntelliShell. Set the appropriate environment variable in your shell profile _before_ the IntelliShell


### PR DESCRIPTION
This updates the documentation (README and docs/src) to show `ctrl+x` as the default AI shortcut, while keeping `ctrl+i` available as a secondary option for supported emulators. It ensures that the documentation is accurate and easier for users to follow, without modifying the underlying default configuration. It also adds a mention to `ctrl+i` in the terminal limitations part of the troubleshooting documentation.

---
*PR created automatically by Jules for task [9379386146638519967](https://jules.google.com/task/9379386146638519967) started by @lasantosr*