### PR TITLE
feat: highlight destructive commands in red

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -159,6 +159,8 @@ accent = "yellow"
 comment = "italic green"
 # The style used for errors
 error = "dark red"
+# The style used for destructive commands
+destructive = "red"
 # The background color for the highlighted item in a list. Use "none" for no background color
 highlight = "darkgrey"
 # The string symbol displayed next to the highlighted item
@@ -171,6 +173,8 @@ highlight_secondary = "default"
 highlight_accent = "yellow"
 # The comments style applied specifically to a highlighted item
 highlight_comment = "italic green"
+# The destructive style applied specifically to a highlighted item
+highlight_destructive = "red"
 
 # --------------------------------------------------------------
 #   Search Tuning

--- a/docs/src/configuration/ai.md
+++ b/docs/src/configuration/ai.md
@@ -11,7 +11,7 @@ through configuring these features.
 AI integration is disabled by default. To turn on all AI-powered functionality, you must first enable it:
 
 ```toml
-{{#include ../../../default_config.toml:246:248}}
+{{#include ../../../default_config.toml:250:252}}
 ```
 
 > 📝 **Note**: By default, IntelliShell is configured to use **Google Gemini**, given that it has a generous free tier.
@@ -39,7 +39,7 @@ Let's look at each part in detail.
 In the `[ai.models]` section, you tell IntelliShell which model from your catalog to use for each specific AI-powered task.
 
 ```toml
-{{#include ../../../default_config.toml:251:262}}
+{{#include ../../../default_config.toml:255:266}}
 ```
 
 ### 2. Model Catalog
@@ -48,7 +48,7 @@ The `[ai.catalog]` section is where you define the connection details for every 
 you to configure multiple models from different providers and easily switch between them in the Task Assignment section.
 
 ```toml
-{{#include ../../../default_config.toml:273:279}}
+{{#include ../../../default_config.toml:277:283}}
 ```
 
 #### Supported Providers

--- a/docs/src/configuration/search_tuning.md
+++ b/docs/src/configuration/search_tuning.md
@@ -14,7 +14,7 @@ The final score for a searched command is a weighted sum of points from three so
 query, how often the command has been used, and the directory where it was last used.
 
 ```toml
-{{#include ../../../default_config.toml:201:234}}
+{{#include ../../../default_config.toml:205:238}}
 ```
 
 ### Command Scoring Parameters
@@ -50,7 +50,7 @@ is determined by a score calculated from two sources: the context of other varia
 the value was used. Total usage count is used as a tie-breaker.
 
 ```toml
-{{#include ../../../default_config.toml:179:199}}
+{{#include ../../../default_config.toml:183:203}}
 ```
 
 ### Variable Scoring Parameters

--- a/docs/src/configuration/theming.md
+++ b/docs/src/configuration/theming.md
@@ -39,17 +39,19 @@ Here is a breakdown of each available key in the `[theme]` section.
 | `accent`             | Used to draw attention to specific parts of the text, like aliases             |
 | `comment`            | The style for descriptions and explanatory text                                |
 | `error`              | The style used to display error messages                                       |
+| `destructive`        | The style used for destructive command text, such as `rm`-like commands        |
 | `highlight`          | The background color for the highlighted item in a list (use `"none"` to skip) |
 | `highlight_symbol`   | The character(s) displayed to the left of the highlighted item                 |
 | `highlight_primary`  | Overrides the `primary` style for the highlighted item only                    |
 | `highlight_secondary`| Overrides the `secondary` style for the highlighted item only                  |
 | `highlight_accent`   | Overrides the `accent` style for the highlighted item only                     |
 | `highlight_comment`  | Overrides the `comment` style for the highlighted item only                    |
+| `highlight_destructive` | Overrides the `destructive` style for highlighted destructive commands      |
 
 ### Default Configuration
 
 ```toml
-{{#include ../../../default_config.toml:138:173}}
+{{#include ../../../default_config.toml:138:177}}
 ```
 
 ## Sample Themes

--- a/docs/src/configuration/theming.md
+++ b/docs/src/configuration/theming.md
@@ -32,21 +32,21 @@ Colors can be specified in several formats:
 
 Here is a breakdown of each available key in the `[theme]` section.
 
-| Key                  | Description                                                                    |
-| -------------------- | ------------------------------------------------------------------------------ |
-| `primary`            | The main style for elements like selected items or important text              |
-| `secondary`          | A less prominent style, often used for unselected items                        |
-| `accent`             | Used to draw attention to specific parts of the text, like aliases             |
-| `comment`            | The style for descriptions and explanatory text                                |
-| `error`              | The style used to display error messages                                       |
-| `destructive`        | The style used for destructive command text, such as `rm`-like commands        |
-| `highlight`          | The background color for the highlighted item in a list (use `"none"` to skip) |
-| `highlight_symbol`   | The character(s) displayed to the left of the highlighted item                 |
-| `highlight_primary`  | Overrides the `primary` style for the highlighted item only                    |
-| `highlight_secondary`| Overrides the `secondary` style for the highlighted item only                  |
-| `highlight_accent`   | Overrides the `accent` style for the highlighted item only                     |
-| `highlight_comment`  | Overrides the `comment` style for the highlighted item only                    |
-| `highlight_destructive` | Overrides the `destructive` style for highlighted destructive commands      |
+| Key                     | Description                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `primary`               | The main style for elements like selected items or important text              |
+| `secondary`             | A less prominent style, often used for unselected items                        |
+| `accent`                | Used to draw attention to specific parts of the text, like aliases             |
+| `comment`               | The style for descriptions and explanatory text                                |
+| `error`                 | The style used to display error messages                                       |
+| `destructive`           | The style used for destructive command text, such as `rm`-like commands        |
+| `highlight`             | The background color for the highlighted item in a list (use `"none"` to skip) |
+| `highlight_symbol`      | The character(s) displayed to the left of the highlighted item                 |
+| `highlight_primary`     | Overrides the `primary` style for the highlighted item only                    |
+| `highlight_secondary`   | Overrides the `secondary` style for the highlighted item only                  |
+| `highlight_accent`      | Overrides the `accent` style for the highlighted item only                     |
+| `highlight_comment`     | Overrides the `comment` style for the highlighted item only                    |
+| `highlight_destructive` | Overrides the `destructive` style for highlighted destructive commands         |
 
 ### Default Configuration
 

--- a/src/component/edit.rs
+++ b/src/component/edit.rs
@@ -130,21 +130,26 @@ impl EditCommandComponent {
             Layout::vertical([Constraint::Length(3), Constraint::Length(3), Constraint::Min(5)]).margin(1)
         };
 
-        Self {
+        let state = Arc::new(RwLock::new(EditCommandComponentState {
+            command,
+            active_field,
+            alias,
+            cmd,
+            description,
+            error,
+        }));
+
+        let ret = Self {
             theme,
             service,
             layout,
             mode,
             global_cancellation_token: cancellation_token,
-            state: Arc::new(RwLock::new(EditCommandComponentState {
-                command,
-                active_field,
-                alias,
-                cmd,
-                description,
-                error,
-            })),
-        }
+            state,
+        };
+
+        ret.state.write().refresh_cmd_style(&ret.theme);
+        ret
     }
 }
 impl<'a> EditCommandComponentState<'a> {
@@ -164,6 +169,16 @@ impl<'a> EditCommandComponentState<'a> {
         self.description.set_focus(false);
 
         self.active_input().set_focus(true);
+    }
+
+    fn refresh_cmd_style(&mut self, theme: &Theme) {
+        let style = if Command::is_destructive_command(&self.cmd.lines_as_string()) {
+            theme.destructive
+        } else {
+            theme.primary
+        };
+
+        self.cmd.set_style(Style::from_crossterm(style));
     }
 }
 
@@ -314,6 +329,7 @@ impl Component for EditCommandComponent {
     fn undo(&mut self) -> Result<Action> {
         let mut state = self.state.write();
         state.active_input().undo();
+        state.refresh_cmd_style(&self.theme);
 
         Ok(Action::NoOp)
     }
@@ -321,6 +337,7 @@ impl Component for EditCommandComponent {
     fn redo(&mut self) -> Result<Action> {
         let mut state = self.state.write();
         state.active_input().redo();
+        state.refresh_cmd_style(&self.theme);
 
         Ok(Action::NoOp)
     }
@@ -328,6 +345,7 @@ impl Component for EditCommandComponent {
     fn insert_text(&mut self, text: String) -> Result<Action> {
         let mut state = self.state.write();
         state.active_input().insert_str(text);
+        state.refresh_cmd_style(&self.theme);
 
         Ok(Action::NoOp)
     }
@@ -335,6 +353,7 @@ impl Component for EditCommandComponent {
     fn insert_char(&mut self, c: char) -> Result<Action> {
         let mut state = self.state.write();
         state.active_input().insert_char(c);
+        state.refresh_cmd_style(&self.theme);
 
         Ok(Action::NoOp)
     }
@@ -349,6 +368,7 @@ impl Component for EditCommandComponent {
     fn delete(&mut self, backspace: bool, word: bool) -> Result<Action> {
         let mut state = self.state.write();
         state.active_input().delete(backspace, word);
+        state.refresh_cmd_style(&self.theme);
 
         Ok(Action::NoOp)
     }
@@ -459,6 +479,7 @@ impl Component for EditCommandComponent {
         let cloned_service = self.service.clone();
         let cloned_state = self.state.clone();
         let cloned_token = self.global_cancellation_token.clone();
+        let theme = self.theme.clone();
         tokio::spawn(async move {
             let res = cloned_service.suggest_command(&cmd, &description, cloned_token).await;
             let mut state = cloned_state.write();
@@ -480,6 +501,7 @@ impl Component for EditCommandComponent {
                         }
                         state.description.insert_str(suggested_description);
                     }
+                    state.refresh_cmd_style(&theme);
                 }
                 Ok(None) => {
                     state

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,6 +150,9 @@ pub struct Theme {
     /// Style for errors
     #[serde(deserialize_with = "deserialize_style")]
     pub error: ContentStyle,
+    /// Style for destructive commands
+    #[serde(deserialize_with = "deserialize_style")]
+    pub destructive: ContentStyle,
     /// Optional background color for highlighted items
     #[serde(deserialize_with = "deserialize_color")]
     pub highlight: Option<Color>,
@@ -167,6 +170,9 @@ pub struct Theme {
     /// Comments style applied when an item is highlighted
     #[serde(deserialize_with = "deserialize_style")]
     pub highlight_comment: ContentStyle,
+    /// Destructive style applied when an item is highlighted
+    #[serde(deserialize_with = "deserialize_style")]
+    pub highlight_destructive: ContentStyle,
 }
 
 /// Configuration settings for the default gist
@@ -835,18 +841,24 @@ impl Default for Theme {
         let mut error = ContentStyle::new();
         error.foreground_color = Some(Color::DarkRed);
 
+        let mut destructive = ContentStyle::new();
+        destructive.foreground_color = Some(Color::Red);
+        let highlight_destructive = destructive;
+
         Self {
             primary,
             secondary,
             accent,
             comment,
             error,
+            destructive,
             highlight: Some(Color::DarkGrey),
             highlight_symbol: String::from("» "),
             highlight_primary,
             highlight_secondary,
             highlight_accent,
             highlight_comment,
+            highlight_destructive,
         }
     }
 }

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -33,6 +33,9 @@ pub const SOURCE_IMPORT: &str = "import";
 /// Source for workspace-level commands
 pub const SOURCE_WORKSPACE: &str = "workspace";
 
+const DESTRUCTIVE_COMMANDS: &[&str] = &["rm", "rmdir", "del", "erase", "rd", "remove-item"];
+const PRIVILEGE_WRAPPERS: &[&str] = &["sudo", "doas"];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, ValueEnum, EnumCycle, strum::Display)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 #[serde(rename_all = "snake_case")]
@@ -196,6 +199,16 @@ impl Command {
     pub fn matches(&self, regex: &Regex) -> bool {
         regex.is_match(&self.cmd) || self.description.as_ref().is_some_and(|d| regex.is_match(d))
     }
+
+    /// Checks whether the command string contains a destructive shell action.
+    pub fn is_destructive(&self) -> bool {
+        Self::is_destructive_command(&self.cmd)
+    }
+
+    /// Checks whether a command string contains a destructive shell action.
+    pub fn is_destructive_command(command: &str) -> bool {
+        split_shell_segments(command).into_iter().any(is_destructive_segment)
+    }
 }
 
 impl Display for Command {
@@ -235,5 +248,230 @@ impl Display for Command {
 
         // Finally, write the command itself
         writeln!(f, "{cmd}")
+    }
+}
+
+fn is_destructive_segment(segment: &str) -> bool {
+    let mut words = ShellWordIter::new(segment);
+
+    for word in words.by_ref() {
+        if is_env_assignment(word) || is_privilege_wrapper(word) {
+            continue;
+        }
+
+        return is_destructive_verb(word) || is_destructive_subcommand(word, &mut words);
+    }
+
+    false
+}
+
+fn is_destructive_verb(word: &str) -> bool {
+    DESTRUCTIVE_COMMANDS.iter().any(|verb| word.eq_ignore_ascii_case(verb))
+}
+
+fn is_privilege_wrapper(word: &str) -> bool {
+    PRIVILEGE_WRAPPERS.iter().any(|wrapper| word.eq_ignore_ascii_case(wrapper))
+}
+
+fn is_destructive_subcommand(command: &str, remaining_words: &mut ShellWordIter<'_>) -> bool {
+    if !command.eq_ignore_ascii_case("git") {
+        return false;
+    }
+
+    remaining_words
+        .next()
+        .is_some_and(is_destructive_verb)
+}
+
+fn is_env_assignment(word: &str) -> bool {
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn split_shell_segments(command: &str) -> Vec<&str> {
+    let bytes = command.as_bytes();
+    let mut segments = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+
+        if escaped {
+            escaped = false;
+            index += 1;
+            continue;
+        }
+
+        if let Some(active_quote) = quote {
+            if byte == b'\\' && active_quote == b'"' {
+                escaped = true;
+            } else if byte == active_quote {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'\\' => {
+                escaped = true;
+                index += 1;
+            }
+            b'\'' | b'"' => {
+                quote = Some(byte);
+                index += 1;
+            }
+            b';' | b'\n' => {
+                segments.push(&command[start..index]);
+                start = index + 1;
+                index += 1;
+            }
+            b'&' if bytes.get(index + 1) == Some(&b'&') => {
+                segments.push(&command[start..index]);
+                start = index + 2;
+                index += 2;
+            }
+            b'|' if bytes.get(index + 1) == Some(&b'|') => {
+                segments.push(&command[start..index]);
+                start = index + 2;
+                index += 2;
+            }
+            b'|' => {
+                segments.push(&command[start..index]);
+                start = index + 1;
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    segments.push(&command[start..]);
+    segments
+}
+
+struct ShellWordIter<'a> {
+    segment: &'a str,
+    cursor: usize,
+}
+
+impl<'a> ShellWordIter<'a> {
+    fn new(segment: &'a str) -> Self {
+        Self { segment, cursor: 0 }
+    }
+}
+
+impl<'a> Iterator for ShellWordIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let bytes = self.segment.as_bytes();
+
+        while let Some(byte) = bytes.get(self.cursor) {
+            if byte.is_ascii_whitespace() {
+                self.cursor += 1;
+            } else {
+                break;
+            }
+        }
+
+        if self.cursor >= bytes.len() {
+            return None;
+        }
+
+        let start = self.cursor;
+        let mut index = self.cursor;
+        let mut quote: Option<u8> = None;
+        let mut escaped = false;
+
+        while index < bytes.len() {
+            let byte = bytes[index];
+
+            if escaped {
+                escaped = false;
+                index += 1;
+                continue;
+            }
+
+            if let Some(active_quote) = quote {
+                if byte == b'\\' && active_quote == b'"' {
+                    escaped = true;
+                } else if byte == active_quote {
+                    quote = None;
+                }
+                index += 1;
+                continue;
+            }
+
+            match byte {
+                b'\\' => {
+                    escaped = true;
+                    index += 1;
+                }
+                b'\'' | b'"' => {
+                    quote = Some(byte);
+                    index += 1;
+                }
+                _ if byte.is_ascii_whitespace() => break,
+                _ => index += 1,
+            }
+        }
+
+        self.cursor = index;
+        Some(&self.segment[start..index])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CATEGORY_USER, Command, SOURCE_USER};
+
+    #[test]
+    fn test_is_destructive_command_positive_cases() {
+        for command in [
+            "rm file",
+            "sudo rm -rf /tmp/x",
+            "VAR=1 rm file",
+            "echo ok && rm file",
+            "git rm file",
+            "Remove-Item foo",
+            "del foo",
+        ] {
+            assert!(Command::is_destructive_command(command), "expected destructive: {command}");
+        }
+    }
+
+    #[test]
+    fn test_is_destructive_command_negative_cases() {
+        for command in [
+            "docker run --rm image",
+            "echo rm file",
+            "printf 'rm file'",
+            "git status",
+            "rmdir_backup",
+            "trash-put foo",
+        ] {
+            assert!(
+                !Command::is_destructive_command(command),
+                "expected non-destructive: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_command_is_destructive_uses_command_text() {
+        let command = Command::new(CATEGORY_USER, SOURCE_USER, "doas erase temp.txt");
+        assert!(command.is_destructive());
     }
 }

--- a/src/utils/markdown.rs
+++ b/src/utils/markdown.rs
@@ -46,13 +46,11 @@ pub fn render_markdown_to_ansi(markdown: &str, theme: &Theme) -> String {
                     }
                     style_stack.push(style);
                 }
-                Tag::Paragraph => {
+                Tag::Paragraph if output.ends_with('\n') || output.is_empty() => {
                     // Only enforce newlines if the buffer ends in a newline (previous block ended)
                     // or is empty. If the buffer ends in text/whitespace (like a list bullet),
                     // we want this paragraph to continue on the same line.
-                    if output.ends_with('\n') || output.is_empty() {
-                        ensure_newlines(&mut output, 2);
-                    }
+                    ensure_newlines(&mut output, 2);
                 }
                 Tag::Emphasis => {
                     let mut style = style_stack.last().cloned().unwrap_or_default();

--- a/src/widgets/command.rs
+++ b/src/widgets/command.rs
@@ -35,6 +35,7 @@ impl<'a> CommandWidget<'a> {
         if is_highlighted && let Some(bg_color) = theme.highlight {
             line_style = line_style.bg(Color::from_crossterm(bg_color));
         }
+
         // Determine the right styles to use based on highlighted and discarded status
         let (primary_style, secondary_style, comment_style, accent_style) =
             match (plain_style, is_discarded, is_highlighted) {
@@ -67,13 +68,25 @@ impl<'a> CommandWidget<'a> {
                 ),
             };
 
+        let destructive_style = if is_highlighted {
+            theme.highlight_destructive
+        } else {
+            theme.destructive
+        };
+        let cmd_style = command.is_destructive().then_some(destructive_style);
+
         // Build command spans
         let cmd_splitter = SplitCaptures::new(&COMMAND_VARIABLE_REGEX, &command.cmd);
         let cmd_spans = cmd_splitter
             .map(|e| match e {
-                SplitItem::Unmatched(t) => Span::styled(t, Style::from_crossterm(primary_style)),
+                SplitItem::Unmatched(t) => {
+                    Span::styled(t, Style::from_crossterm(cmd_style.unwrap_or(primary_style)))
+                }
                 SplitItem::Captured(l) => {
-                    Span::styled(l.get(0).unwrap().as_str(), Style::from_crossterm(secondary_style))
+                    Span::styled(
+                        l.get(0).unwrap().as_str(),
+                        Style::from_crossterm(cmd_style.unwrap_or(secondary_style)),
+                    )
                 }
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
Add destructive-command detection for obvious shell delete actions, including rm-like commands and git rm.

Use the new detection to render destructive commands with dedicated theme styles in command lists, import/export previews, and the command editor. Add configurable destructive and highlight_destructive theme keys, update the theming docs, and cover the matcher with unit tests.