### PR TITLE
Fix root command extraction with shell variables and operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "shell-words",
  "signal-hook 0.4.3",
  "strip-ansi-escapes",
  "strum 0.28.0",
@@ -3559,6 +3560,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ sea-query-rusqlite    = { version = "0.8.0-rc.8", features = ["with-chrono", "wi
 semver                = "1"
 serde                 = { version = "1", features = ["derive", "rc"] }
 serde_json            = "1"
+shell-words = "1.1.1"
 signal-hook           = "0.4"
 strip-ansi-escapes    = "0.2"
 strum                 = { version = "0.28", features = ["derive"] }

--- a/src/model/template.rs
+++ b/src/model/template.rs
@@ -13,6 +13,7 @@ use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_decode_str, utf8_perc
 use super::VariableValue;
 use crate::utils::{
     COMMAND_VARIABLE_REGEX, COMMAND_VARIABLE_REGEX_ALT, SplitCaptures, SplitItem, flatten_str, flatten_variable_name,
+    extract_root_cmd,
 };
 
 /// A command containing variables
@@ -44,7 +45,7 @@ impl CommandTemplate {
             .collect::<Vec<_>>();
 
         CommandTemplate {
-            flat_root_cmd: flatten_str(cmd.split_whitespace().next().unwrap_or(cmd)),
+            flat_root_cmd: flatten_str(extract_root_cmd(cmd).as_deref().unwrap_or(cmd)),
             parts,
         }
     }

--- a/src/service/ai.rs
+++ b/src/service/ai.rs
@@ -13,7 +13,7 @@ use crate::{
     errors::{AppError, Result, UserFacingError},
     model::{CATEGORY_USER, Command, SOURCE_AI, SearchMode},
     utils::{
-        ShellType, add_tags_to_description, execute_shell_command_capture, generate_working_dir_tree,
+        ShellType, add_tags_to_description, execute_shell_command_capture, extract_root_cmd, generate_working_dir_tree,
         get_executable_version, get_os_info, get_shell_info,
     },
 };
@@ -74,8 +74,8 @@ impl IntelliShellService {
         on_progress(AiFixProgress::Thinking);
 
         // Prepare prompts and call the AI provider
-        let root_cmd = command.split_whitespace().next();
-        let sys_prompt = replace_prompt_placeholders(&self.ai.prompts.fix, root_cmd, history);
+        let root_cmd = extract_root_cmd(command);
+        let sys_prompt = replace_prompt_placeholders(&self.ai.prompts.fix, root_cmd.as_deref(), history);
         let user_prompt = format!(
             "I've run a command but it failed, help me fix it.\n\ncommand: \
              {command}\n{status}\noutput:\n```\n{output}\n```"

--- a/src/service/export.rs
+++ b/src/service/export.rs
@@ -24,7 +24,7 @@ use crate::{
     utils::{
         ShellType,
         dto::{GIST_README_FILENAME, GIST_README_FILENAME_UPPER, GistDto, GistFileDto, ImportExportItemDto},
-        extract_gist_data, extract_variables, flatten_str, get_export_gist_token, get_shell_type,
+        extract_gist_data, extract_root_cmd, extract_variables, flatten_str, get_export_gist_token, get_shell_type,
     },
 };
 
@@ -52,7 +52,7 @@ impl IntelliShellService {
 
                 // Extract all variables from the command and accumulate them for later
                 if is_filtered {
-                    let flat_root_cmd = flatten_str(command.cmd.split_whitespace().next().unwrap_or(""));
+                    let flat_root_cmd = flatten_str(extract_root_cmd(&command.cmd).as_deref().unwrap_or(""));
                     if !flat_root_cmd.is_empty() {
                         let variables = extract_variables(&command.cmd);
                         for variable in variables {

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -191,12 +191,11 @@ pub fn extract_root_cmd(command: &str) -> Option<String> {
         }
 
         // if the part itself is `$env.VAR` and the next part is `=`
-        if p.starts_with("$env.") || p.starts_with("$env:") {
-            if parts.get(i + 1).map(|s| s.as_str()) == Some("=") {
+        if (p.starts_with("$env.") || p.starts_with("$env:"))
+            && parts.get(i + 1).map(|s| s.as_str()) == Some("=") {
                 skip_next_n = 2; // skip `=` and `val`
                 continue;
             }
-        }
 
         if p.starts_with('-') {
             continue;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -109,3 +109,142 @@ fn flatten(s: impl AsRef<str>, forbidden_chars: &Regex) -> String {
         .trim()
         .to_string()
 }
+
+/// Extracts the root command from a shell command string, skipping environment variables and common prefixes
+/// like `sudo`, `time`, etc., as well as shell operators like `&&` or `;`.
+pub fn extract_root_cmd(command: &str) -> Option<String> {
+    fn is_env_var(s: &str) -> bool {
+        // Handle PowerShell: `$env:VAR=val`, Nushell `$env.VAR=val`
+        let s = s.trim_start_matches("$env:").trim_start_matches("$env.");
+
+        let mut parts = s.splitn(2, '=');
+        let name = parts.next().unwrap_or("");
+
+        if name.is_empty() || parts.next().is_none() {
+            return false;
+        }
+
+        // Allow basic alphanumeric, underscore, and dots/colons from some shells
+        name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == ':')
+    }
+
+    let parts = match shell_words::split(command) {
+        Ok(p) => p,
+        Err(_) => command.split_whitespace().map(|s| s.to_string()).collect(),
+    };
+
+    let mut skip_next_n = 0;
+
+    for (i, part) in parts.iter().enumerate() {
+        if skip_next_n > 0 {
+            skip_next_n -= 1;
+            continue;
+        }
+
+        let p = part.as_str();
+
+        // Strip trailing semicolons or other separators that might have attached to the word in fallback parsing
+        let p = p.strip_suffix(';').unwrap_or(p);
+
+        if is_env_var(p) {
+            continue;
+        }
+
+        match p {
+            "&&" | "||" | ";" | "|" | "sudo" | "doas" | "time" | "env" | "function" | "def" | "def-env" | "export" => {
+                continue;
+            }
+            // Nushell assignment like: `let-env VAR = "val"` or `$env.VAR = "val"`
+            "let-env" | "let" | "mut" => {
+                // Skips variable name, `=`, and value (e.g. `let-env VAR = val`)
+                // In some cases it's just `let VAR = val`
+                if parts.get(i + 2).map(|s| s.as_str()) == Some("=") {
+                    skip_next_n = 3;
+                } else if parts.get(i + 1).map(|s| s.as_str()) == Some("=") {
+                    // maybe `let-env = val` ?
+                    skip_next_n = 2;
+                } else {
+                    // let VAR val (unlikely in Nushell, but just to be safe)
+                    skip_next_n = 2;
+                }
+                continue;
+            }
+            // Fish assignment like `set -x VAR val` or `set VAR val`
+            "set" => {
+                // Skip everything in `parts` until we hit a delimiter, then let the loop resume from there.
+                let mut skipped = 0;
+                for next_part in parts.iter().skip(i + 1) {
+                    let next_part_stripped = next_part.as_str().strip_suffix(';').unwrap_or(next_part.as_str());
+                    if matches!(next_part_stripped, ";" | "&&" | "||" | "|") {
+                        break;
+                    }
+                    skipped += 1;
+                    if next_part.as_str().ends_with(';') {
+                        // The token has `;` attached to it (e.g. `val;`).
+                        break;
+                    }
+                }
+                skip_next_n = skipped;
+                continue;
+            }
+            _ => {}
+        }
+
+        // if the part itself is `$env.VAR` and the next part is `=`
+        if p.starts_with("$env.") || p.starts_with("$env:") {
+            if parts.get(i + 1).map(|s| s.as_str()) == Some("=") {
+                skip_next_n = 2; // skip `=` and `val`
+                continue;
+            }
+        }
+
+        if p.starts_with('-') {
+            continue;
+        }
+
+        let trimmed = p.strip_suffix("()").unwrap_or(p).to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_root_cmd() {
+        assert_eq!(extract_root_cmd("VAR1=val1 VAR2=\"val2\" root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("VAR4='value 4' && root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("VAR5=val\\ 5 ; root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("sudo root arg1 arg2").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("time sudo root arg1 arg2").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("env VAR=1 root arg1").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("root arg1").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd(""), None);
+        assert_eq!(extract_root_cmd("VAR=val"), None);
+        assert_eq!(extract_root_cmd("my_fn() { echo a; }").as_deref(), Some("my_fn"));
+        assert_eq!(extract_root_cmd("function my_fn() { echo a; }").as_deref(), Some("my_fn"));
+        assert_eq!(extract_root_cmd("function my_fn { echo a; }").as_deref(), Some("my_fn"));
+        assert_eq!(extract_root_cmd("ENV={{variable-name:kebab}} function my_fn() { echo a; }").as_deref(), Some("my_fn"));
+
+        // PowerShell
+        assert_eq!(extract_root_cmd("$env:VAR=\"val\"; root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("$env:VAR=val; root argument").as_deref(), Some("root"));
+
+        // Nushell
+        assert_eq!(extract_root_cmd("let-env VAR = \"val\"; root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("let VAR = \"val\"; root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("$env.VAR = \"val\"; root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("def my_fn [] { echo a }").as_deref(), Some("my_fn"));
+        assert_eq!(extract_root_cmd("def-env my_fn [] { echo a }").as_deref(), Some("my_fn"));
+
+        // Fish
+        assert_eq!(extract_root_cmd("env VAR=val root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("function my_fn; echo a; end").as_deref(), Some("my_fn"));
+        assert_eq!(extract_root_cmd("export VAR=val; root argument").as_deref(), Some("root"));
+        assert_eq!(extract_root_cmd("set -x VAR val; root argument").as_deref(), Some("root"));
+    }
+}


### PR DESCRIPTION
- Added `shell-words` dependency.
- Implemented `extract_root_cmd` in `src/utils/string.rs` with unit tests covering various shell prefix and quoting scenarios.
- Used `extract_root_cmd` in `src/service/ai.rs`, `src/service/export.rs`, and `src/model/template.rs` replacing the naive `.split_whitespace().next()`.

---
*PR created automatically by Jules for task [73964168488901449](https://jules.google.com/task/73964168488901449) started by @lasantosr*